### PR TITLE
Leverage latest clarity features

### DIFF
--- a/clarinet/contracts/main-swapr.clar
+++ b/clarinet/contracts/main-swapr.clar
@@ -52,22 +52,25 @@
 
 
 (define-read-only (get-name (token-x-trait <sip-010-token>) (token-y-trait <sip-010-token>))
-  (let ((token-x (contract-of token-x-trait)) (token-y (contract-of token-y-trait)))
-    (let ((pair (unwrap! (map-get? pairs-data-map { token-x: token-x, token-y: token-y }) invalid-pair-err)))
-      (ok (get name pair))
-    )
+  (let ((token-x (contract-of token-x-trait))
+        (token-y (contract-of token-y-trait))
+        (pair (unwrap! (map-get? pairs-data-map { token-x: token-x, token-y: token-y }) invalid-pair-err)))
+    (ok (get name pair))
   )
 )
 
 (define-public (get-symbol (token-x-trait <sip-010-token>) (token-y-trait <sip-010-token>))
-  (ok (concat (unwrap-panic (as-max-len? (unwrap-panic (contract-call? token-x-trait get-symbol)) u15)) (concat "-" (unwrap-panic (as-max-len? (unwrap-panic (contract-call? token-y-trait get-symbol)) u15)))))
+  (ok (concat 
+    (unwrap-panic (as-max-len? (unwrap-panic (contract-call? token-x-trait get-symbol)) u15)) 
+    (concat "-" 
+    (unwrap-panic (as-max-len? (unwrap-panic (contract-call? token-y-trait get-symbol)) u15)))))
 )
 
 (define-read-only (get-total-supply (token-x-trait <sip-010-token>) (token-y-trait <sip-010-token>))
-  (let ((token-x (contract-of token-x-trait)) (token-y (contract-of token-y-trait)))
-    (let ((pair (unwrap! (map-get? pairs-data-map { token-x: token-x, token-y: token-y }) invalid-pair-err)))
-      (ok (get shares-total pair))
-    )
+  (let ((token-x (contract-of token-x-trait))
+        (token-y (contract-of token-y-trait))
+        (pair (unwrap! (map-get? pairs-data-map { token-x: token-x, token-y: token-y }) invalid-pair-err)))
+    (ok (get shares-total pair))
   )
 )
 
@@ -78,10 +81,10 @@
 
 ;; get overall balances for the pair
 (define-public (get-balances (token-x-trait <sip-010-token>) (token-y-trait <sip-010-token>))
-  (let ((token-x (contract-of token-x-trait)) (token-y (contract-of token-y-trait)))
-    (let ((pair (unwrap! (map-get? pairs-data-map { token-x: token-x, token-y: token-y }) invalid-pair-err)))
-      (ok (list (get balance-x pair) (get balance-y pair)))
-    )
+  (let ((token-x (contract-of token-x-trait)) 
+        (token-y (contract-of token-y-trait))
+        (pair (unwrap! (map-get? pairs-data-map { token-x: token-x, token-y: token-y }) invalid-pair-err)))
+    (ok (list (get balance-x pair) (get balance-y pair)))
   )
 )
 
@@ -89,52 +92,32 @@
 ;; (define-constant x-token 'SP2NC4YKZWM2YMCJV851VF278H9J50ZSNM33P3JM1.my-token)
 ;; (define-constant y-token 'SP1QR3RAGH3GEME9WV7XB0TZCX6D5MNDQP97D35EH.my-token)
 (define-public (add-to-position (token-x-trait <sip-010-token>) (token-y-trait <sip-010-token>) (token-swapr-trait <swapr-token>) (x uint) (y uint))
-  (let ((token-x (contract-of token-x-trait)) (token-y (contract-of token-y-trait)))
-    (let ((pair (unwrap! (map-get? pairs-data-map { token-x: token-x, token-y: token-y }) invalid-pair-err)) (contract-address (as-contract tx-sender)) (recipient-address tx-sender) (balance-x (get balance-x pair)) (balance-y (get balance-y pair)))
+  (let ((token-x (contract-of token-x-trait)) 
+        (token-y (contract-of token-y-trait))
+        (pair (unwrap-panic (map-get? pairs-data-map { token-x: token-x, token-y: token-y })))
+        (contract-address (as-contract tx-sender)) 
+        (recipient-address tx-sender)
+        (balance-x (get balance-x pair))
+        (balance-y (get balance-y pair))
+        (new-shares (if (is-eq (get shares-total pair) u0)
+          (sqrti (* x y))
+          (/ (* x (get shares-total pair)) balance-x)))
+        (pair-updated (merge pair {
+          shares-total: (+ new-shares (get shares-total pair)),
+          balance-x: (+ balance-x x),
+          balance-y: (+ balance-y y)
+        })))
       ;; TODO(psq) check if x or y is 0, to calculate proper exchange rate unless shares-total is 0, which would be an error
-      (if
-        (and
-          ;; TODO(psq): check that the amount transfered in matches the amount requested
-          (is-ok (contract-call? token-x-trait transfer x tx-sender contract-address))
-          (is-ok (contract-call? token-y-trait transfer y tx-sender contract-address))
-        )
-        (begin
-          (print "calculate new-shares")
-          (let ((new-shares (if (is-eq (print (get shares-total pair)) u0)
-                  (let ((shares (sqrti (* x y))))
-                    ;; (increase-shares token-x token-y tx-sender shares)
-                    shares
-                  )
-                  (let ((shares (/ (* (print x) (print (get shares-total pair))) balance-x)))
-                    ;; (increase-shares token-x token-y tx-sender shares)
-                    shares
-                  )
-                )))
-            (map-set pairs-data-map { token-x: token-x, token-y: token-y }
-              {
-                shares-total: (+ new-shares (get shares-total pair)),
-                balance-x: (+ balance-x x),
-                balance-y: (+ balance-y y),
-                fee-balance-x: (get fee-balance-x pair),
-                fee-balance-y: (get fee-balance-y pair),
-                fee-to-address: (get fee-to-address pair),
-                name: (get name pair),
-                swapr-token: (get swapr-token pair),
-              }
-            )
-            (print "token-swapr-trait.mint params")
-            (print x)
-            (print y)
-            (print recipient-address)
-            (print new-shares)
-            (print (contract-call? token-swapr-trait mint recipient-address new-shares))
-          )
-        )
-        (begin
-          transfer-failed-err
-        )
-      )
-    )
+    (asserts! 
+      (and ;; TODO(psq): check that the amount transfered in matches the amount requested
+        (is-ok (contract-call? token-x-trait transfer x tx-sender contract-address))
+        (is-ok (contract-call? token-y-trait transfer y tx-sender contract-address)))
+      transfer-failed-err)
+
+    (map-set pairs-data-map { token-x: token-x, token-y: token-y } pair-updated)
+    (try! (contract-call? token-swapr-trait mint recipient-address new-shares))
+    (print { object: "position", action: "add-to-position", data: pair-updated })
+    (ok true)
   )
 )
 
@@ -157,73 +140,73 @@
 (define-public (create-pair (token-x-trait <sip-010-token>) (token-y-trait <sip-010-token>) (token-swapr-trait <swapr-token>) (pair-name (string-ascii 32)) (x uint) (y uint))
   ;; TOOD(psq): add creation checks, then create map before proceeding to add-to-position
   ;; check neither x,y or y,x exists`
-  (let ((name-x (unwrap-panic (contract-call? token-x-trait get-name))) (name-y (unwrap-panic (contract-call? token-y-trait get-name))))
-    (let ((token-x (contract-of token-x-trait)) (token-y (contract-of token-y-trait)) (pair-id (+ (var-get pair-count) u1)))
-      (if (and (is-none (map-get? pairs-data-map { token-x: token-x, token-y: token-y })) (is-none (map-get? pairs-data-map { token-x: token-y, token-y: token-x })))
-        (begin
-          (map-set pairs-data-map { token-x: token-x, token-y: token-y }
-            {
-              shares-total: u0,
-              balance-x: u0,
-              balance-y: u0,
-              fee-balance-x: u0,
-              fee-balance-y: u0,
-              fee-to-address: none,
-              swapr-token: (contract-of token-swapr-trait),
-              name: pair-name,
-            }
-          )
-          (map-set pairs-map { pair-id: pair-id } { token-x: token-x, token-y: token-y })
-          ;; (var-set pairs-list (unwrap! (as-max-len? (append (var-get pairs-list) pair-id) u2000) too-many-pairs-err))
-          (var-set pair-count pair-id)
-          (add-to-position token-x-trait token-y-trait token-swapr-trait x y)
-        )
-        pair-already-exists-err
-      )
-    )
+  (let ((name-x (unwrap-panic (contract-call? token-x-trait get-name))) 
+        (name-y (unwrap-panic (contract-call? token-y-trait get-name)))
+        (token-x (contract-of token-x-trait)) 
+        (token-y (contract-of token-y-trait)) 
+        (pair-id (+ (var-get pair-count) u1))
+        (pair-data {
+          shares-total: u0,
+          balance-x: u0,
+          balance-y: u0,
+          fee-balance-x: u0,
+          fee-balance-y: u0,
+          fee-to-address: none,
+          swapr-token: (contract-of token-swapr-trait),
+          name: pair-name,
+        }))
+
+    (asserts! 
+      (and 
+        (is-none (map-get? pairs-data-map { token-x: token-x, token-y: token-y }))
+        (is-none (map-get? pairs-data-map { token-x: token-y, token-y: token-x })))
+      pair-already-exists-err)
+
+    (map-set pairs-data-map { token-x: token-x, token-y: token-y } pair-data)
+      
+    (map-set pairs-map { pair-id: pair-id } { token-x: token-x, token-y: token-y })
+    ;; (var-set pairs-list (unwrap! (as-max-len? (append (var-get pairs-list) pair-id) u2000) too-many-pairs-err))
+    (var-set pair-count pair-id)
+    (try! (add-to-position token-x-trait token-y-trait token-swapr-trait x y))
+    (print { object: "pair", action: "created", data: pair-data })
+    (ok true)
   )
 )
-
-
 
 ;; ;; reduce the amount of liquidity the sender provides to the pool
 ;; ;; to close, use u100
 (define-public (reduce-position (token-x-trait <sip-010-token>) (token-y-trait <sip-010-token>) (token-swapr-trait <swapr-token>) (percent uint))
-  (let ((token-x (contract-of token-x-trait)) (token-y (contract-of token-y-trait)))
-    (let ((pair (unwrap! (map-get? pairs-data-map { token-x: token-x, token-y: token-y }) invalid-pair-err)) (balance-x (get balance-x pair)) (balance-y (get balance-y pair)))
-      (let ((shares (unwrap-panic (contract-call? token-swapr-trait get-balance-of tx-sender))) (shares-total (get shares-total pair)) (contract-address (as-contract tx-sender)) (sender tx-sender))
-        (let ((withdrawal (/ (* shares percent) u100)))
-          (let ((withdrawal-x (/ (* withdrawal balance-x) shares-total)) (withdrawal-y (/ (* withdrawal balance-y) shares-total)))
-            (if
-              (and
-                (<= percent u100)
-                (is-ok (as-contract (contract-call? token-x-trait transfer withdrawal-x contract-address sender)))
-                (is-ok (as-contract (contract-call? token-y-trait transfer withdrawal-y contract-address sender)))
-              )
-              (begin
-                ;; (unwrap-panic (decrease-shares token-x token-y tx-sender withdrawal)) ;; should never fail, you know...
-                (map-set pairs-data-map { token-x: token-x, token-y: token-y }
-                  {
-                    shares-total: (- shares-total withdrawal),
-                    balance-x: (- (get balance-x pair) withdrawal-x),
-                    balance-y: (- (get balance-y pair) withdrawal-y),
-                    fee-balance-x: (get fee-balance-x pair),
-                    fee-balance-y: (get fee-balance-y pair),
-                    fee-to-address: (get fee-to-address pair),
-                    name: (get name pair),
-                    swapr-token: (get swapr-token pair),
-                  }
-                )
-                ;; TODO(psq): use burn
-                (unwrap-panic (contract-call? token-swapr-trait transfer withdrawal tx-sender contract-address))  ;; transfer back to swapr, wish there was a burn instead...
-                (ok (list withdrawal-x withdrawal-y))
-              )
-              transfer-failed-err
-            )
-          )
-        )
-      )
-    )
+  (let ((token-x (contract-of token-x-trait)) 
+       (token-y (contract-of token-y-trait))
+       (pair (unwrap! (map-get? pairs-data-map { token-x: token-x, token-y: token-y }) invalid-pair-err))
+       (balance-x (get balance-x pair))
+       (balance-y (get balance-y pair))
+       (shares (unwrap-panic (contract-call? token-swapr-trait get-balance-of tx-sender))) 
+       (shares-total (get shares-total pair))
+       (contract-address (as-contract tx-sender))
+       (sender tx-sender)
+       (withdrawal (/ (* shares percent) u100))
+       (withdrawal-x (/ (* withdrawal balance-x) shares-total)) 
+       (withdrawal-y (/ (* withdrawal balance-y) shares-total))
+       (pair-updated (merge pair {
+          shares-total: (- shares-total withdrawal),
+          balance-x: (- (get balance-x pair) withdrawal-x),
+          balance-y: (- (get balance-y pair) withdrawal-y)
+        })))
+
+    (asserts!
+      (and
+        (<= percent u100)
+        (is-ok (as-contract (contract-call? token-x-trait transfer withdrawal-x contract-address sender)))
+        (is-ok (as-contract (contract-call? token-y-trait transfer withdrawal-y contract-address sender))))
+      transfer-failed-err)
+    
+    ;; (unwrap-panic (decrease-shares token-x token-y tx-sender withdrawal)) ;; should never fail, you know...
+    (map-set pairs-data-map { token-x: token-x, token-y: token-y } pair-updated)
+    ;; TODO(psq): use burn
+    (unwrap-panic (contract-call? token-swapr-trait transfer withdrawal tx-sender contract-address))  ;; transfer back to swapr, wish there was a burn instead...
+    (print { object: "pair", action: "reduce-position", data: pair-updated })
+    (ok (list withdrawal-x withdrawal-y))
   )
 )
 
@@ -234,47 +217,35 @@
   ;; calculate fee on dx
   ;; transfer
   ;; update balances
-  (let ((token-x (contract-of token-x-trait)) (token-y (contract-of token-y-trait)))
-    (let ((pair (unwrap! (map-get? pairs-data-map { token-x: token-x, token-y: token-y }) invalid-pair-err)) (balance-x (get balance-x pair)) (balance-y (get balance-y pair)))
-      (let
-        (
-          (contract-address (as-contract tx-sender))
-          (sender tx-sender)
-          (dy (/ (* u997 balance-y dx) (+ (* u1000 balance-x) (* u997 dx)))) ;; overall fee is 30 bp, either all for the pool, or 25 bp for pool and 5 bp for operator
-          (fee (/ (* u5 dx) u10000)) ;; 5 bp
-        )
-        (if (< min-dy dy)
-          (if (and
-            ;; TODO(psq): check that the amount transfered in matches the amount requested
-              (is-ok (contract-call? token-x-trait transfer dx sender contract-address))
-              (is-ok (as-contract (contract-call? token-y-trait transfer dy contract-address sender)))
-            )
-            (begin
-              (map-set pairs-data-map { token-x: token-x, token-y: token-y }
-                {
-                  shares-total: (get shares-total pair),
-                  balance-x: (+ (get balance-x pair) dx),
-                  balance-y: (- (get balance-y pair) dy),
-                  fee-balance-x:
-                    (if (is-some (get fee-to-address pair))  ;; only collect fee when fee-to-address is set
-                      (+ fee (get fee-balance-x pair))
-                      (get fee-balance-x pair)
-                    )
-                  ,
-                  fee-balance-y: (get fee-balance-y pair),
-                  fee-to-address: (get fee-to-address pair),
-                  name: (get name pair),
-                  swapr-token: (get swapr-token pair),
-                }
-              )
-              (ok (list dx dy))
-            )
-            transfer-failed-err
-          )
-          too-much-slippage-err
-        )
-      )
-    )
+  (let ((token-x (contract-of token-x-trait))
+        (token-y (contract-of token-y-trait))
+        (pair (unwrap! (map-get? pairs-data-map { token-x: token-x, token-y: token-y }) invalid-pair-err)) 
+        (balance-x (get balance-x pair)) 
+        (balance-y (get balance-y pair))
+        (contract-address (as-contract tx-sender))
+        (sender tx-sender)
+        (dy (/ (* u997 balance-y dx) (+ (* u1000 balance-x) (* u997 dx)))) ;; overall fee is 30 bp, either all for the pool, or 25 bp for pool and 5 bp for operator
+        (fee (/ (* u5 dx) u10000)) ;; 5 bp
+        (pair-updated (merge pair {
+          balance-x: (+ (get balance-x pair) dx),
+          balance-y: (- (get balance-y pair) dy),
+          fee-balance-x: (if (is-some (get fee-to-address pair))  ;; only collect fee when fee-to-address is set
+            (+ fee (get fee-balance-x pair))
+            (get fee-balance-x pair))
+        })))
+
+    (asserts! (< min-dy dy) too-much-slippage-err)
+
+    (asserts! 
+      (and
+        ;; TODO(psq): check that the amount transfered in matches the amount requested
+        (is-ok (contract-call? token-x-trait transfer dx sender contract-address))
+        (is-ok (as-contract (contract-call? token-y-trait transfer dy contract-address sender))))
+      transfer-failed-err)
+
+    (map-set pairs-data-map { token-x: token-x, token-y: token-y } pair-updated)
+    (print { object: "pair", action: "swap-x-for-y", data: pair-updated })
+    (ok (list dx dy))
   )
 )
 
@@ -285,72 +256,58 @@
   ;; calculate fee on dy
   ;; transfer
   ;; update balances
-  (let ((token-x (contract-of token-x-trait)) (token-y (contract-of token-y-trait)))
-    (let ((pair (unwrap! (map-get? pairs-data-map { token-x: token-x, token-y: token-y }) invalid-pair-err)) (balance-x (get balance-x pair)) (balance-y (get balance-y pair)))
-      (let
-        (
-          (contract-address (as-contract tx-sender))
-          (sender tx-sender)
-          ;; check formula, vs x-for-y???
-          (dx (/ (* u997 balance-x dy) (+ (* u1000 balance-y) (* u997 dy)))) ;; overall fee is 30 bp, either all for the pool, or 25 bp for pool and 5 bp for operator
-          (fee (/ (* u5 dy) u10000)) ;; 5 bp
-        )
-        (if (< min-dx dx)
-          (if (and
-            ;; TODO(psq): check that the amount transfered in matches the amount requested
-            (is-ok (as-contract (contract-call? token-x-trait transfer dx contract-address sender)))
-            (is-ok (contract-call? token-y-trait transfer dy sender contract-address))
-            )
-            (begin
-              (map-set pairs-data-map { token-x: token-x, token-y: token-y }
-                {
-                  shares-total: (get shares-total pair),
-                  balance-x: (- (get balance-x pair) dx),
-                  balance-y: (+ (get balance-y pair) dy),
-                  fee-balance-x: (get fee-balance-x pair),
-                  fee-balance-y:
-                    (if (is-some (get fee-to-address pair))  ;; only collect fee when fee-to-address is set
-                      (+ fee (get fee-balance-y pair))
-                      (get fee-balance-y pair)
-                    )
-                  ,
-                  fee-to-address: (get fee-to-address pair),
-                  name: (get name pair),
-                  swapr-token: (get swapr-token pair),
-                }
-              )
-              (ok (list dx dy))
-            )
-            transfer-failed-err
-          )
-          too-much-slippage-err
-        )
-      )
-    )
+  (let ((token-x (contract-of token-x-trait)) 
+        (token-y (contract-of token-y-trait))
+        (pair (unwrap! (map-get? pairs-data-map { token-x: token-x, token-y: token-y }) invalid-pair-err))
+        (balance-x (get balance-x pair))
+        (balance-y (get balance-y pair))
+        (contract-address (as-contract tx-sender))
+        (sender tx-sender)
+        ;; check formula, vs x-for-y???
+        (dx (/ (* u997 balance-x dy) (+ (* u1000 balance-y) (* u997 dy)))) ;; overall fee is 30 bp, either all for the pool, or 25 bp for pool and 5 bp for operator
+        (fee (/ (* u5 dy) u10000)) ;; 5 bp
+        (pair-updated (merge pair {
+          balance-x: (- (get balance-x pair) dx),
+          balance-y: (+ (get balance-y pair) dy),
+          fee-balance-y: (if (is-some (get fee-to-address pair))  ;; only collect fee when fee-to-address is set
+            (+ fee (get fee-balance-y pair))
+            (get fee-balance-y pair))
+        })))
+
+    (asserts! (< min-dx dx) too-much-slippage-err)
+
+    (asserts! 
+      (and
+        ;; TODO(psq): check that the amount transfered in matches the amount requested
+        (is-ok (as-contract (contract-call? token-x-trait transfer dx contract-address sender)))
+        (is-ok (contract-call? token-y-trait transfer dy sender contract-address)))
+      transfer-failed-err)
+
+    (map-set pairs-data-map { token-x: token-x, token-y: token-y } pair-updated)
+    (print { object: "pair", action: "swap-y-for-x", data: pair-updated })
+    (ok (list dx dy))
   )
 )
 
 ;; ;; activate the contract fee for swaps by setting the collection address, restricted to contract owner
 (define-public (set-fee-to-address (token-x principal) (token-y principal) (address principal))
   (let ((pair (unwrap! (map-get? pairs-data-map { token-x: token-x, token-y: token-y }) invalid-pair-err)))
-    (if (is-eq tx-sender contract-owner)
-      (begin
-        (map-set pairs-data-map { token-x: token-x, token-y: token-y }
-          {
-            shares-total: (get shares-total pair),
-            balance-x: (get balance-y pair),
-            balance-y: (get balance-y pair),
-            fee-balance-x: (get fee-balance-y pair),
-            fee-balance-y: (get fee-balance-y pair),
-            fee-to-address: (some address),
-            name: (get name pair),
-            swapr-token: (get swapr-token pair),
-          }
-        )
-        (ok true)
-      )
-      not-owner-err
+
+    (asserts! (is-eq tx-sender contract-owner) not-owner-err)
+
+    (map-set pairs-data-map { token-x: token-x, token-y: token-y }
+      {
+        shares-total: (get shares-total pair),
+        balance-x: (get balance-y pair),
+        balance-y: (get balance-y pair),
+        fee-balance-x: (get fee-balance-y pair),
+        fee-balance-y: (get fee-balance-y pair),
+        fee-to-address: (some address),
+        name: (get name pair),
+        swapr-token: (get swapr-token pair),
+      }
     )
+    (ok true)
   )
 )
 
@@ -358,24 +315,22 @@
 ;; ;; TODO(psq): if there are any collected fees, prevent this from happening, as the fees can no longer be collect with `collect-fees`
 (define-public (reset-fee-to-address (token-x principal) (token-y principal))
   (let ((pair (unwrap! (map-get? pairs-data-map { token-x: token-x, token-y: token-y }) invalid-pair-err)))
-    (if (is-eq tx-sender contract-owner)
-      (begin
-        (map-set pairs-data-map { token-x: token-x, token-y: token-y }
-          {
-            shares-total: (get shares-total pair),
-            balance-x: (get balance-x pair),
-            balance-y: (get balance-y pair),
-            fee-balance-x: (get fee-balance-y pair),
-            fee-balance-y: (get fee-balance-y pair),
-            fee-to-address: none,
-            name: (get name pair),
-            swapr-token: (get swapr-token pair),
-          }
-        )
-        (ok true)
-      )
-      not-owner-err
+
+    (asserts! (is-eq tx-sender contract-owner) not-owner-err)
+
+    (map-set pairs-data-map { token-x: token-x, token-y: token-y }
+      {
+        shares-total: (get shares-total pair),
+        balance-x: (get balance-x pair),
+        balance-y: (get balance-y pair),
+        fee-balance-x: (get fee-balance-y pair),
+        fee-balance-y: (get fee-balance-y pair),
+        fee-to-address: none,
+        name: (get name pair),
+        swapr-token: (get swapr-token pair),
+      }
     )
+    (ok true)
   )
 )
 
@@ -395,32 +350,38 @@
 
 ;; ;; send the collected fees the fee-to-address
 (define-public (collect-fees (token-x-trait <sip-010-token>) (token-y-trait <sip-010-token>))
-  (let ((token-x (contract-of token-x-trait)) (token-y (contract-of token-y-trait)) (contract-address (as-contract tx-sender)))
-    (let ((pair (unwrap! (map-get? pairs-data-map { token-x: token-x, token-y: token-y }) invalid-pair-err)))
-      (let ((address (unwrap! (get fee-to-address pair) no-fee-to-address-err)) (fee-x (get fee-balance-x pair)) (fee-y (get fee-balance-y pair)))
-        (if
-          (and
-            (or (is-eq fee-x u0) (is-ok (as-contract (contract-call? token-x-trait transfer fee-x contract-address address))))
-            (or (is-eq fee-y u0) (is-ok (as-contract (contract-call? token-y-trait transfer fee-y contract-address address))))
-          )
-          (begin
-            (map-set pairs-data-map { token-x: token-x, token-y: token-y }
-              {
-                shares-total: (get shares-total pair),
-                balance-x: (get balance-x pair),
-                balance-y: (get balance-y pair),
-                fee-balance-x: u0,
-                fee-balance-y: u0,
-                fee-to-address: (get fee-to-address pair),
-                name: (get name pair),
-                swapr-token: (get swapr-token pair),
-              }
-            )
-            (ok (list fee-x fee-y))
-          )
-          transfer-failed-err
-        )
-      )
+  (let ((token-x (contract-of token-x-trait)) 
+        (token-y (contract-of token-y-trait))
+        (contract-address (as-contract tx-sender))
+        (pair (unwrap! (map-get? pairs-data-map { token-x: token-x, token-y: token-y }) invalid-pair-err))
+        (address (unwrap! (get fee-to-address pair) no-fee-to-address-err))
+        (fee-x (get fee-balance-x pair))
+        (fee-y (get fee-balance-y pair)))
+  
+    (asserts!
+      (or
+        (is-eq fee-x u0) 
+        (is-ok (as-contract (contract-call? token-x-trait transfer fee-x contract-address address))))
+      transfer-failed-err)
+
+    (asserts!
+      (or
+        (is-eq fee-y u0) 
+        (is-ok (as-contract (contract-call? token-y-trait transfer fee-y contract-address address))))
+      transfer-failed-err)
+
+    (map-set pairs-data-map { token-x: token-x, token-y: token-y }
+      {
+        shares-total: (get shares-total pair),
+        balance-x: (get balance-x pair),
+        balance-y: (get balance-y pair),
+        fee-balance-x: u0,
+        fee-balance-y: u0,
+        fee-to-address: (get fee-to-address pair),
+        name: (get name pair),
+        swapr-token: (get swapr-token pair),
+      }
     )
+    (ok (list fee-x fee-y))
   )
 )

--- a/clarinet/contracts/main-swapr.clar
+++ b/clarinet/contracts/main-swapr.clar
@@ -116,7 +116,7 @@
 
     (map-set pairs-data-map { token-x: token-x, token-y: token-y } pair-updated)
     (try! (contract-call? token-swapr-trait mint recipient-address new-shares))
-    (print { object: "position", action: "add-to-position", data: pair-updated })
+    (print { object: "pair", action: "liquidity-added", data: pair-updated })
     (ok true)
   )
 )
@@ -205,7 +205,7 @@
     (map-set pairs-data-map { token-x: token-x, token-y: token-y } pair-updated)
     ;; TODO(psq): use burn
     (unwrap-panic (contract-call? token-swapr-trait transfer withdrawal tx-sender contract-address))  ;; transfer back to swapr, wish there was a burn instead...
-    (print { object: "pair", action: "reduce-position", data: pair-updated })
+    (print { object: "pair", action: "liquidity-removed", data: pair-updated })
     (ok (list withdrawal-x withdrawal-y))
   )
 )

--- a/clarinet/tests/plaid-stx-token_test.js
+++ b/clarinet/tests/plaid-stx-token_test.js
@@ -1,5 +1,5 @@
 
-import { Clarinet, Tx, types } from 'https://deno.land/x/clarinet@v0.5.0/index.ts';
+import { Clarinet, Tx, types } from 'https://deno.land/x/clarinet@v0.6.0/index.ts';
 import { assertEquals } from 'https://deno.land/std@0.90.0/testing/asserts.ts';
 
 Clarinet.test({

--- a/clarinet/tests/plaid-token_test.js
+++ b/clarinet/tests/plaid-token_test.js
@@ -1,5 +1,5 @@
 
-import { Clarinet, Tx, types } from 'https://deno.land/x/clarinet@v0.5.0/index.ts';
+import { Clarinet, Tx, types } from 'https://deno.land/x/clarinet@v0.6.0/index.ts';
 import { assertEquals } from 'https://deno.land/std@0.90.0/testing/asserts.ts';
 
 Clarinet.test({

--- a/clarinet/tests/stx-token_test.js
+++ b/clarinet/tests/stx-token_test.js
@@ -1,5 +1,5 @@
 
-import { Clarinet, Tx, types } from 'https://deno.land/x/clarinet@v0.5.0/index.ts';
+import { Clarinet, Tx, types } from 'https://deno.land/x/clarinet@v0.6.0/index.ts';
 import { assertEquals } from 'https://deno.land/std@0.90.0/testing/asserts.ts';
 
 Clarinet.test({

--- a/clarinet/tests/swapr_test.js
+++ b/clarinet/tests/swapr_test.js
@@ -1,4 +1,4 @@
-import { Clarinet, Tx, types } from 'https://deno.land/x/clarinet@v0.5.2/index.ts'
+import { Clarinet, Tx, types } from 'https://deno.land/x/clarinet@v0.6.0/index.ts'
 // import { Clarinet, Tx, types } from './clarinet.ts'
 import { assertEquals, assertExists } from 'https://deno.land/std@0.90.0/testing/asserts.ts'
 import { unwrapList, unwrapOK, unwrapTuple, unwrapUInt, parse } from './utils.js'


### PR DESCRIPTION
Nothing too fancy in this PR, I simply went through the swapr contract, and trying to demonstrate how can the latest clarity features can be used for DRY'ing a contract.
Usually speaking, I try to use `assert!` over `if`, because it's way easier to increase the number of checks with `asserts`.
I also took the freedom of emitting more events, so we can increase observability for this contract. 